### PR TITLE
src: make action compatible with ubuntu-20.04 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     - run: |
         npm install
         npm run all
+
   integration: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     strategy:
@@ -32,3 +33,17 @@ jobs:
       with:
         name: 'snap'
         path: ${{ steps.snapcraft.outputs.snap}}
+
+  check-runner: # make sure the action works on each VM image
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-16.04
+          - ubuntu-18.04
+          - ubuntu-20.04
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        path: './test-projects/core18'

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -177,8 +177,8 @@ test('ensureLXD removes the apt version of LXD', async () => {
   ])
 })
 
-test('ensureLXD is a no-op if LXD is installed', async () => {
-  expect.assertions(3)
+test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
+  expect.assertions(4)
 
   const accessMock = jest.spyOn(fs.promises, 'access').mockImplementation(
     async (filename: fs.PathLike, mode?: number | undefined): Promise<void> => {
@@ -210,6 +210,7 @@ test('ensureLXD is a no-op if LXD is installed', async () => {
     'lxd',
     os.userInfo().username
   ])
+  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', ['lxd', 'init', '--auto'])
 })
 
 test('ensureSnapcraft installs Snapcraft if needed', async () => {

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -114,7 +114,7 @@ test('ensureSnapd fixes permissions on the root directory', async () => {
 })
 
 test('ensureLXD installs the snap version of LXD if needed', async () => {
-  expect.assertions(4)
+  expect.assertions(5)
 
   const accessMock = jest.spyOn(fs.promises, 'access').mockImplementation(
     async (filename: fs.PathLike, mode?: number | undefined): Promise<void> => {
@@ -129,20 +129,26 @@ test('ensureLXD installs the snap version of LXD if needed', async () => {
 
   await tools.ensureLXD()
 
-  expect(accessMock).toHaveBeenCalled()
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
-    'snap',
-    'install',
+    'groupadd',
+    '--force',
+    '--system',
     'lxd'
   ])
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', ['lxd', 'init', '--auto'])
-  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', [
+  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
     'usermod',
     '--append',
     '--groups',
     'lxd',
     os.userInfo().username
   ])
+  expect(accessMock).toHaveBeenCalled()
+  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', [
+    'snap',
+    'install',
+    'lxd'
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })
 
 test('ensureLXD removes the apt version of LXD', async () => {
@@ -172,7 +178,7 @@ test('ensureLXD removes the apt version of LXD', async () => {
 })
 
 test('ensureLXD is a no-op if LXD is installed', async () => {
-  expect.assertions(2)
+  expect.assertions(3)
 
   const accessMock = jest.spyOn(fs.promises, 'access').mockImplementation(
     async (filename: fs.PathLike, mode?: number | undefined): Promise<void> => {
@@ -191,7 +197,19 @@ test('ensureLXD is a no-op if LXD is installed', async () => {
   await tools.ensureLXD()
 
   expect(accessMock).toHaveBeenCalled()
-  expect(execMock).not.toHaveBeenCalled()
+  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+    'groupadd',
+    '--force',
+    '--system',
+    'lxd'
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+    'usermod',
+    '--append',
+    '--groups',
+    'lxd',
+    os.userInfo().username
+  ])
 })
 
 test('ensureSnapcraft installs Snapcraft if needed', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1391,8 +1391,9 @@ function ensureLXD() {
         if (!haveSnapLXD) {
             Object(core.info)('Installing LXD...');
             yield Object(exec.exec)('sudo', ['snap', 'install', 'lxd']);
-            yield Object(exec.exec)('sudo', ['lxd', 'init', '--auto']);
         }
+        Object(core.info)('Initialising LXD...');
+        yield Object(exec.exec)('sudo', ['lxd', 'init', '--auto']);
     });
 }
 function ensureSnapcraft() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1377,18 +1377,21 @@ function ensureLXD() {
             Object(core.info)('Removing legacy .deb packaged LXD...');
             yield Object(exec.exec)('sudo', ['apt-get', 'remove', '-qy', 'lxd', 'lxd-client']);
         }
+        Object(core.info)(`Ensuring ${Object(external_os_.userInfo)().username} is in the lxd group...`);
+        yield Object(exec.exec)('sudo', ['groupadd', '--force', '--system', 'lxd']);
+        yield Object(exec.exec)('sudo', [
+            'usermod',
+            '--append',
+            '--groups',
+            'lxd',
+            Object(external_os_.userInfo)().username
+        ]);
+        // Ensure that the "lxd" group exists
         const haveSnapLXD = yield haveExecutable('/snap/bin/lxd');
         if (!haveSnapLXD) {
             Object(core.info)('Installing LXD...');
             yield Object(exec.exec)('sudo', ['snap', 'install', 'lxd']);
             yield Object(exec.exec)('sudo', ['lxd', 'init', '--auto']);
-            yield Object(exec.exec)('sudo', [
-                'usermod',
-                '--append',
-                '--groups',
-                'lxd',
-                Object(external_os_.userInfo)().username
-            ]);
         }
     });
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -35,18 +35,23 @@ export async function ensureLXD(): Promise<void> {
     core.info('Removing legacy .deb packaged LXD...')
     await exec.exec('sudo', ['apt-get', 'remove', '-qy', 'lxd', 'lxd-client'])
   }
+
+  core.info(`Ensuring ${os.userInfo().username} is in the lxd group...`)
+  await exec.exec('sudo', ['groupadd', '--force', '--system', 'lxd'])
+  await exec.exec('sudo', [
+    'usermod',
+    '--append',
+    '--groups',
+    'lxd',
+    os.userInfo().username
+  ])
+
+  // Ensure that the "lxd" group exists
   const haveSnapLXD = await haveExecutable('/snap/bin/lxd')
   if (!haveSnapLXD) {
     core.info('Installing LXD...')
     await exec.exec('sudo', ['snap', 'install', 'lxd'])
     await exec.exec('sudo', ['lxd', 'init', '--auto'])
-    await exec.exec('sudo', [
-      'usermod',
-      '--append',
-      '--groups',
-      'lxd',
-      os.userInfo().username
-    ])
   }
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -51,8 +51,9 @@ export async function ensureLXD(): Promise<void> {
   if (!haveSnapLXD) {
     core.info('Installing LXD...')
     await exec.exec('sudo', ['snap', 'install', 'lxd'])
-    await exec.exec('sudo', ['lxd', 'init', '--auto'])
   }
+  core.info('Initialising LXD...')
+  await exec.exec('sudo', ['lxd', 'init', '--auto'])
 }
 
 export async function ensureSnapcraft(): Promise<void> {


### PR DESCRIPTION
`snapcore/action-build@v1` currently fails when run on the `ubuntu-20.04` image, hanging on a password prompt.  The likely cause is that there is no "lxd" group allowing the CI user to manage containers.

This PR makes sure the "lxd" group exists before installing the LXD snap.

Fixes #3.