### PR TITLE
src: expand '~' in project root path

### DIFF
--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -1,6 +1,8 @@
 // -*- mode: javascript; js-indent-level: 2 -*-
 
-import fs = require('fs')
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import * as process from 'process'
 import * as exec from '@actions/exec'
 import * as build from '../src/build'
@@ -8,6 +10,14 @@ import * as tools from '../src/tools'
 
 afterEach(() => {
   jest.restoreAllMocks()
+})
+
+test('SnapcraftBuilder expands tilde in project root', () => {
+  let builder = new build.SnapcraftBuilder('~', true)
+  expect(builder.projectRoot).toBe(os.homedir())
+
+  builder = new build.SnapcraftBuilder('~/foo/bar', true)
+  expect(builder.projectRoot).toBe(path.join(os.homedir(), 'foo/bar'))
 })
 
 test('SnapcraftBuilder.build runs a snap build', async () => {

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -1,9 +1,9 @@
 // -*- mode: javascript; js-indent-level: 2 -*-
 
-import * as exec from '@actions/exec'
-import fs = require('fs')
+import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import * as exec from '@actions/exec'
 import * as tools from '../src/tools'
 
 afterEach(() => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1316,6 +1316,9 @@ var core = __webpack_require__(470);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __webpack_require__(747);
 
+// EXTERNAL MODULE: external "os"
+var external_os_ = __webpack_require__(87);
+
 // EXTERNAL MODULE: external "path"
 var external_path_ = __webpack_require__(622);
 
@@ -1324,9 +1327,6 @@ var external_process_ = __webpack_require__(765);
 
 // EXTERNAL MODULE: ./node_modules/@actions/exec/lib/exec.js
 var exec = __webpack_require__(986);
-
-// EXTERNAL MODULE: external "os"
-var external_os_ = __webpack_require__(87);
 
 // CONCATENATED MODULE: ./lib/tools.js
 // -*- mode: javascript; js-indent-level: 2 -*-
@@ -1423,9 +1423,16 @@ var build_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 
 
 
+
+function expandHome(p) {
+    if (p === '~' || p.startsWith('~/')) {
+        p = Object(external_os_.homedir)() + p.slice(1);
+    }
+    return p;
+}
 class build_SnapcraftBuilder {
     constructor(projectRoot, includeBuildInfo) {
-        this.projectRoot = projectRoot;
+        this.projectRoot = expandHome(projectRoot);
         this.includeBuildInfo = includeBuildInfo;
     }
     build() {

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,6 +1,7 @@
 // -*- mode: javascript; js-indent-level: 2 -*-
 
 import * as fs from 'fs'
+import * as os from 'os'
 import * as path from 'path'
 import * as process from 'process'
 import * as core from '@actions/core'
@@ -14,12 +15,19 @@ interface ImageInfo {
   build_url?: string
 }
 
+function expandHome(p: string): string {
+  if (p === '~' || p.startsWith('~/')) {
+    p = os.homedir() + p.slice(1)
+  }
+  return p
+}
+
 export class SnapcraftBuilder {
   projectRoot: string
   includeBuildInfo: boolean
 
   constructor(projectRoot: string, includeBuildInfo: boolean) {
-    this.projectRoot = projectRoot
+    this.projectRoot = expandHome(projectRoot)
     this.includeBuildInfo = includeBuildInfo
   }
 


### PR DESCRIPTION
If the user puts their project in the CI user's home directory (instead of the default workspace directory), they might want to specify that path using the common shell `~` notation.  This currently results in an error, which is confusing to people who don't realise that tilde expansion is a shell feature rather than a kernel or C library feature.

This PR does the bare minimum of expanding the current user's home directory in paths.

Fixes #1.