### PR TITLE
src: add snapcraft-channel and snapcraft-args input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,6 @@ jobs:
 This will install and configure LXD and Snapcraft, then invoke
 `snapcraft` to build the project.
 
-It assumes that the Snapcraft project is at the root of the
-repository.  If this is not the case, then the action can be
-configured with the `path` input parameter:
-
-```yaml
-...
-    - uses: snapcore/action-build@v1
-      with:
-        path: path-to-snapcraft-project
-```
-
 On success, the action will set the `snap` output parameter to the
 path of the built snap.  This can be used to save it as an artifact of
 the workflow:
@@ -52,3 +41,49 @@ Alternatively, it could be used to perform further testing on the built snap:
         sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
         # do something with the snap
 ```
+
+The action can also be chained with
+[`snapcore/action-publish@v1`](https://github.com/snapcore/action-publish)
+to automatically publish builds to the Snap Store.
+
+
+## Action inputs
+
+### `path`
+
+If your Snapcraft project is not located in the root of the workspace,
+you can specify an alternative location via the `path` input
+parameter:
+
+```yaml
+...
+    - uses: snapcore/action-build@v1
+      with:
+        path: path-to-snapcraft-project
+```
+
+### `build-info`
+
+By default, the action will tell Snapcraft to include information
+about the build in the resulting snap, in the form of the
+`snap/snapcraft.yaml` and `snap/manifest.yaml` files.  Among other
+things, these are used by the Snap Store's automatic security
+vulnerability scanner to check whether your snap includes files from
+vulnerable versions of Ubuntu packages.
+
+This can be turned off by setting the `build-info` parameter to
+`false`.
+
+### `snapcraft-channel`
+
+By default, the action will install Snapcraft from the stable
+channel.  If your project relies on a feature not found in the stable
+version of Snapcraft, then the `snapcraft-channel` parameter can be
+used to select a different channel.
+
+### `snapcraft-args`
+
+The `snapcraft-args` parameter can be used to pass additional
+arguments to Snapcraft.  This is primarily intended to allow the use
+of experimental features by passing `--enable-experimental-*`
+arguments to Snapcraft.

--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -13,10 +13,10 @@ afterEach(() => {
 })
 
 test('SnapcraftBuilder expands tilde in project root', () => {
-  let builder = new build.SnapcraftBuilder('~', true)
+  let builder = new build.SnapcraftBuilder('~', true, 'stable', '')
   expect(builder.projectRoot).toBe(os.homedir())
 
-  builder = new build.SnapcraftBuilder('~/foo/bar', true)
+  builder = new build.SnapcraftBuilder('~/foo/bar', true, 'stable', '')
   expect(builder.projectRoot).toBe(path.join(os.homedir(), 'foo/bar'))
 })
 
@@ -31,7 +31,7 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
     .mockImplementation(async (): Promise<void> => {})
   const ensureSnapcraft = jest
     .spyOn(tools, 'ensureSnapcraft')
-    .mockImplementation(async (): Promise<void> => {})
+    .mockImplementation(async (channel): Promise<void> => {})
   const execMock = jest.spyOn(exec, 'exec').mockImplementation(
     async (program: string, args?: string[]): Promise<number> => {
       return 0
@@ -41,7 +41,7 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
   process.env['GITHUB_RUN_ID'] = '42'
 
   const projectDir = 'project-root'
-  const builder = new build.SnapcraftBuilder(projectDir, true)
+  const builder = new build.SnapcraftBuilder(projectDir, true, 'stable', '')
   await builder.build()
 
   expect(ensureSnapd).toHaveBeenCalled()
@@ -69,14 +69,14 @@ test('SnapcraftBuilder.build can disable build info', async () => {
     .mockImplementation(async (): Promise<void> => {})
   const ensureSnapcraft = jest
     .spyOn(tools, 'ensureSnapcraft')
-    .mockImplementation(async (): Promise<void> => {})
+    .mockImplementation(async (channel): Promise<void> => {})
   const execMock = jest.spyOn(exec, 'exec').mockImplementation(
     async (program: string, args?: string[]): Promise<number> => {
       return 0
     }
   )
 
-  const builder = new build.SnapcraftBuilder('.', false)
+  const builder = new build.SnapcraftBuilder('.', false, 'stable', '')
   await builder.build()
 
   expect(execMock).toHaveBeenCalledWith('sg', expect.any(Array), {
@@ -88,11 +88,68 @@ test('SnapcraftBuilder.build can disable build info', async () => {
   })
 })
 
+test('SnapcraftBuilder.build can set the Snapcraft channel', async () => {
+  expect.assertions(1)
+
+  const ensureSnapd = jest
+    .spyOn(tools, 'ensureSnapd')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureLXD = jest
+    .spyOn(tools, 'ensureLXD')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureSnapcraft = jest
+    .spyOn(tools, 'ensureSnapcraft')
+    .mockImplementation(async (channel): Promise<void> => {})
+  const execMock = jest.spyOn(exec, 'exec').mockImplementation(
+    async (program: string, args?: string[]): Promise<number> => {
+      return 0
+    }
+  )
+
+  const builder = new build.SnapcraftBuilder('.', false, 'edge', '')
+  await builder.build()
+
+  expect(ensureSnapcraft).toHaveBeenCalledWith('edge')
+})
+
+test('SnapcraftBuilder.build can pass additional arguments', async () => {
+  expect.assertions(1)
+
+  const ensureSnapd = jest
+    .spyOn(tools, 'ensureSnapd')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureLXD = jest
+    .spyOn(tools, 'ensureLXD')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureSnapcraft = jest
+    .spyOn(tools, 'ensureSnapcraft')
+    .mockImplementation(async (channel): Promise<void> => {})
+  const execMock = jest.spyOn(exec, 'exec').mockImplementation(
+    async (program: string, args?: string[]): Promise<number> => {
+      return 0
+    }
+  )
+
+  const builder = new build.SnapcraftBuilder(
+    '.',
+    false,
+    'stable',
+    '--foo --bar'
+  )
+  await builder.build()
+
+  expect(execMock).toHaveBeenCalledWith(
+    'sg',
+    ['lxd', '-c', 'snapcraft --foo --bar'],
+    expect.anything()
+  )
+})
+
 test('SnapcraftBuilder.outputSnap fails if there are no snaps', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
-  const builder = new build.SnapcraftBuilder(projectDir, true)
+  const builder = new build.SnapcraftBuilder(projectDir, true, 'stable', '')
 
   const readdir = jest
     .spyOn(builder, '_readdir')
@@ -110,7 +167,7 @@ test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
-  const builder = new build.SnapcraftBuilder(projectDir, true)
+  const builder = new build.SnapcraftBuilder(projectDir, true, 'stable', '')
 
   const readdir = jest
     .spyOn(builder, '_readdir')

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -178,7 +178,7 @@ test('ensureLXD removes the apt version of LXD', async () => {
 })
 
 test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
-  expect.assertions(4)
+  expect.assertions(5)
 
   const accessMock = jest.spyOn(fs.promises, 'access').mockImplementation(
     async (filename: fs.PathLike, mode?: number | undefined): Promise<void> => {
@@ -210,7 +210,12 @@ test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
     'lxd',
     os.userInfo().username
   ])
-  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', ['lxd', 'init', '--auto'])
+  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', [
+    'snap',
+    'refresh',
+    'lxd'
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })
 
 test('ensureSnapcraft installs Snapcraft if needed', async () => {
@@ -227,18 +232,20 @@ test('ensureSnapcraft installs Snapcraft if needed', async () => {
     }
   )
 
-  await tools.ensureSnapcraft()
+  await tools.ensureSnapcraft('edge')
 
   expect(accessMock).toHaveBeenCalled()
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
     'snap',
     'install',
+    '--channel',
+    'edge',
     '--classic',
     'snapcraft'
   ])
 })
 
-test('ensureSnapcraft is a no-op if Snapcraft is installed', async () => {
+test('ensureSnapcraft refreshes if Snapcraft is installed', async () => {
   expect.assertions(2)
 
   const accessMock = jest.spyOn(fs.promises, 'access').mockImplementation(
@@ -252,8 +259,15 @@ test('ensureSnapcraft is a no-op if Snapcraft is installed', async () => {
     }
   )
 
-  await tools.ensureSnapcraft()
+  await tools.ensureSnapcraft('edge')
 
   expect(accessMock).toHaveBeenCalled()
-  expect(execMock).not.toHaveBeenCalled()
+  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+    'snap',
+    'refresh',
+    '--channel',
+    'edge',
+    '--classic',
+    'snapcraft'
+  ])
 })

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,22 @@ inputs:
       Proprietary applications may want to disable this due to
       the information leakage.
     default: 'true'
+  snapcraft-channel:
+    description: >
+      The Snapcraft channel to use
+
+      By default, the action will use the stable version of Snapcraft
+      to build the project.  This parameter can be used to instead
+      select a different channel such as beta, candidate, or edge.
+    default: 'stable'
+  snapcraft-args:
+    description: >
+      Additional arguments to pass to Snapcraft
+
+      Some experimental Snapcraft features are disabled by default and
+      must be turned on via a `--enable-experimental-*` command line
+      argument.  This parameter can be used to turn on such features.
+    default: ''
 outputs:
   snap:
     description: 'The file name of the resulting snap.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,9 +1152,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.63.tgz",
-      "integrity": "sha512-jRP6uNtUKAFz3Cl7zwCKW9hoRSNzuNSsQ3sLGSv5Uf+yWQvx226DF9a0Moa3HADkIp7ae/FhLwlqQzrgfg9hFg==",
+      "version": "14.11.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.4.tgz",
+      "integrity": "sha512-KmoLCUeW2cWKkEOQ0gQcECuqOc0g7B7zcmRPQNMT4ntNm0luKv3BTLcqIyWpTxkhLDzLTdMus11j/6DROaZdPw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.14",
-    "@types/node": "^12.12.63",
+    "@types/node": "^14.11.4",
     "@typescript-eslint/parser": "^4.4.0",
     "@zeit/ncc": "^0.22.3",
     "eslint": "^7.10.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,15 @@ async function run(): Promise<void> {
     const buildInfo =
       (core.getInput('build-info') || 'true').toUpperCase() === 'TRUE'
     core.info(`Building Snapcraft project in "${path}"...`)
+    const snapcraftChannel = core.getInput('snapcraft-channel')
+    const snapcraftArgs = core.getInput('snapcraft-args')
 
-    const builder = new SnapcraftBuilder(path, buildInfo)
+    const builder = new SnapcraftBuilder(
+      path,
+      buildInfo,
+      snapcraftChannel,
+      snapcraftArgs
+    )
     await builder.build()
     const snap = await builder.outputSnap()
     core.setOutput('snap', snap)

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -48,18 +48,21 @@ export async function ensureLXD(): Promise<void> {
 
   // Ensure that the "lxd" group exists
   const haveSnapLXD = await haveExecutable('/snap/bin/lxd')
-  if (!haveSnapLXD) {
-    core.info('Installing LXD...')
-    await exec.exec('sudo', ['snap', 'install', 'lxd'])
-  }
+  core.info('Installing LXD...')
+  await exec.exec('sudo', ['snap', haveSnapLXD ? 'refresh' : 'install', 'lxd'])
   core.info('Initialising LXD...')
   await exec.exec('sudo', ['lxd', 'init', '--auto'])
 }
 
-export async function ensureSnapcraft(): Promise<void> {
+export async function ensureSnapcraft(channel: string): Promise<void> {
   const haveSnapcraft = await haveExecutable('/snap/bin/snapcraft')
-  if (!haveSnapcraft) {
-    core.info('Installing Snapcraft...')
-    await exec.exec('sudo', ['snap', 'install', '--classic', 'snapcraft'])
-  }
+  core.info('Installing Snapcraft...')
+  await exec.exec('sudo', [
+    'snap',
+    haveSnapcraft ? 'refresh' : 'install',
+    '--channel',
+    channel,
+    '--classic',
+    'snapcraft'
+  ])
 }


### PR DESCRIPTION
This PR adds support for picking a build of Snapcraft other than the stable version, and passing extra arguments to Snapcraft, as you would need to for things like `--enable-experimental-package-repositories`.

Fixes #8.