### PR TITLE
src: convert SnapcraftBuilder constructor to take an options object as an argument

### DIFF
--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -13,10 +13,22 @@ afterEach(() => {
 })
 
 test('SnapcraftBuilder expands tilde in project root', () => {
-  let builder = new build.SnapcraftBuilder('~', true, 'stable', '', '')
+  let builder = new build.SnapcraftBuilder({
+    projectRoot: '~',
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
   expect(builder.projectRoot).toBe(os.homedir())
 
-  builder = new build.SnapcraftBuilder('~/foo/bar', true, 'stable', '', '')
+  builder = new build.SnapcraftBuilder({
+    projectRoot: '~/foo/bar',
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
   expect(builder.projectRoot).toBe(path.join(os.homedir(), 'foo/bar'))
 })
 
@@ -41,7 +53,13 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
   process.env['GITHUB_RUN_ID'] = '42'
 
   const projectDir = 'project-root'
-  const builder = new build.SnapcraftBuilder(projectDir, true, 'stable', '', '')
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: projectDir,
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
   await builder.build()
 
   expect(ensureSnapd).toHaveBeenCalled()
@@ -76,7 +94,13 @@ test('SnapcraftBuilder.build can disable build info', async () => {
     }
   )
 
-  const builder = new build.SnapcraftBuilder('.', false, 'stable', '', '')
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: '.',
+    includeBuildInfo: false,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
   await builder.build()
 
   expect(execMock).toHaveBeenCalledWith('sg', expect.any(Array), {
@@ -106,7 +130,13 @@ test('SnapcraftBuilder.build can set the Snapcraft channel', async () => {
     }
   )
 
-  const builder = new build.SnapcraftBuilder('.', false, 'edge', '', '')
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: '.',
+    includeBuildInfo: false,
+    snapcraftChannel: 'edge',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
   await builder.build()
 
   expect(ensureSnapcraft).toHaveBeenCalledWith('edge')
@@ -130,13 +160,13 @@ test('SnapcraftBuilder.build can pass additional arguments', async () => {
     }
   )
 
-  const builder = new build.SnapcraftBuilder(
-    '.',
-    false,
-    'stable',
-    '--foo --bar',
-    ''
-  )
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: '.',
+    includeBuildInfo: false,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '--foo --bar',
+    uaToken: ''
+  })
   await builder.build()
 
   expect(execMock).toHaveBeenCalledWith(
@@ -164,13 +194,13 @@ test('SnapcraftBuilder.build can pass UA token', async () => {
     }
   )
 
-  const builder = new build.SnapcraftBuilder(
-    '.',
-    false,
-    'stable',
-    '',
-    'test-ua-token'
-  )
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: '.',
+    includeBuildInfo: false,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: 'test-ua-token'
+  })
   await builder.build()
 
   expect(execMock).toHaveBeenCalledWith(
@@ -184,7 +214,13 @@ test('SnapcraftBuilder.outputSnap fails if there are no snaps', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
-  const builder = new build.SnapcraftBuilder(projectDir, true, 'stable', '', '')
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: projectDir,
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
 
   const readdir = jest
     .spyOn(builder, '_readdir')
@@ -202,7 +238,13 @@ test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
-  const builder = new build.SnapcraftBuilder(projectDir, true, 'stable', '', '')
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: projectDir,
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: '',
+    uaToken: ''
+  })
 
   const readdir = jest
     .spyOn(builder, '_readdir')

--- a/dist/index.js
+++ b/dist/index.js
@@ -1500,12 +1500,12 @@ function expandHome(p) {
     return p;
 }
 class build_SnapcraftBuilder {
-    constructor(projectRoot, includeBuildInfo, snapcraftChannel, snapcraftArgs, uaToken) {
-        this.projectRoot = expandHome(projectRoot);
-        this.includeBuildInfo = includeBuildInfo;
-        this.snapcraftChannel = snapcraftChannel;
-        this.snapcraftArgs = snapcraftArgs;
-        this.uaToken = uaToken;
+    constructor(options) {
+        this.projectRoot = expandHome(options.projectRoot);
+        this.includeBuildInfo = options.includeBuildInfo;
+        this.snapcraftChannel = options.snapcraftChannel;
+        this.snapcraftArgs = options.snapcraftArgs;
+        this.uaToken = options.uaToken;
     }
     build() {
         return build_awaiter(this, void 0, void 0, function* () {
@@ -1577,13 +1577,19 @@ var main_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
 function run() {
     return main_awaiter(this, void 0, void 0, function* () {
         try {
-            const path = Object(core.getInput)('path');
-            const buildInfo = (Object(core.getInput)('build-info') || 'true').toUpperCase() === 'TRUE';
-            Object(core.info)(`Building Snapcraft project in "${path}"...`);
+            const projectRoot = Object(core.getInput)('path');
+            const includeBuildInfo = (Object(core.getInput)('build-info') || 'true').toUpperCase() === 'TRUE';
+            Object(core.info)(`Building Snapcraft project in "${projectRoot}"...`);
             const snapcraftChannel = Object(core.getInput)('snapcraft-channel');
             const snapcraftArgs = Object(core.getInput)('snapcraft-args');
             const uaToken = Object(core.getInput)('ua-token');
-            const builder = new build_SnapcraftBuilder(path, buildInfo, snapcraftChannel, snapcraftArgs, uaToken);
+            const builder = new build_SnapcraftBuilder({
+                projectRoot,
+                includeBuildInfo,
+                snapcraftChannel,
+                snapcraftArgs,
+                uaToken
+            });
             yield builder.build();
             const snap = yield builder.outputSnap();
             Object(core.setOutput)('snap', snap);

--- a/src/build.ts
+++ b/src/build.ts
@@ -22,6 +22,14 @@ function expandHome(p: string): string {
   return p
 }
 
+interface SnapcraftBuilderOptions {
+  projectRoot: string
+  includeBuildInfo: boolean
+  snapcraftChannel: string
+  snapcraftArgs: string
+  uaToken: string
+}
+
 export class SnapcraftBuilder {
   projectRoot: string
   includeBuildInfo: boolean
@@ -29,18 +37,12 @@ export class SnapcraftBuilder {
   snapcraftArgs: string
   uaToken: string
 
-  constructor(
-    projectRoot: string,
-    includeBuildInfo: boolean,
-    snapcraftChannel: string,
-    snapcraftArgs: string,
-    uaToken: string
-  ) {
-    this.projectRoot = expandHome(projectRoot)
-    this.includeBuildInfo = includeBuildInfo
-    this.snapcraftChannel = snapcraftChannel
-    this.snapcraftArgs = snapcraftArgs
-    this.uaToken = uaToken
+  constructor(options: SnapcraftBuilderOptions) {
+    this.projectRoot = expandHome(options.projectRoot)
+    this.includeBuildInfo = options.includeBuildInfo
+    this.snapcraftChannel = options.snapcraftChannel
+    this.snapcraftArgs = options.snapcraftArgs
+    this.uaToken = options.uaToken
   }
 
   async build(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,21 +5,21 @@ import {SnapcraftBuilder} from './build'
 
 async function run(): Promise<void> {
   try {
-    const path = core.getInput('path')
-    const buildInfo =
+    const projectRoot = core.getInput('path')
+    const includeBuildInfo =
       (core.getInput('build-info') || 'true').toUpperCase() === 'TRUE'
-    core.info(`Building Snapcraft project in "${path}"...`)
+    core.info(`Building Snapcraft project in "${projectRoot}"...`)
     const snapcraftChannel = core.getInput('snapcraft-channel')
     const snapcraftArgs = core.getInput('snapcraft-args')
     const uaToken = core.getInput('ua-token')
 
-    const builder = new SnapcraftBuilder(
-      path,
-      buildInfo,
+    const builder = new SnapcraftBuilder({
+      projectRoot,
+      includeBuildInfo,
       snapcraftChannel,
       snapcraftArgs,
       uaToken
-    )
+    })
     await builder.build()
     const snap = await builder.outputSnap()
     core.setOutput('snap', snap)


### PR DESCRIPTION
We have 4 string arguments to SnapcraftBuilder's constructor, which was getting to the point that you could forget their ordering.  This PR switches over to passing the options as an object with a TypeScript interface to ensure the property names are correct.