### PR TITLE
tools: logic to remove docker if installed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         path: ${{ steps.snapcraft.outputs.snap}}
 
   integration-legacy: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         project:

--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -33,8 +33,11 @@ test('SnapcraftBuilder expands tilde in project root', () => {
 })
 
 test('SnapcraftBuilder.build runs a snap build', async () => {
-  expect.assertions(4)
+  expect.assertions(5)
 
+  const ensureDockerRemoved = jest
+    .spyOn(tools, 'ensureDockerRemoved')
+    .mockImplementation(async (): Promise<void> => {})
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
     .mockImplementation(async (): Promise<void> => {})
@@ -64,6 +67,7 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
   })
   await builder.build()
 
+  expect(ensureDockerRemoved).toHaveBeenCalled()
   expect(ensureSnapd).toHaveBeenCalled()
   expect(ensureLXD).toHaveBeenCalled()
   expect(ensureSnapcraft).toHaveBeenCalled()
@@ -81,6 +85,9 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
 test('SnapcraftBuilder.build can disable build info', async () => {
   expect.assertions(1)
 
+  const ensureDockerRemoved = jest
+    .spyOn(tools, 'ensureDockerRemoved')
+    .mockImplementation(async (): Promise<void> => {})
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
     .mockImplementation(async (): Promise<void> => {})
@@ -119,6 +126,9 @@ test('SnapcraftBuilder.build can disable build info', async () => {
 test('SnapcraftBuilder.build can set the Snapcraft channel', async () => {
   expect.assertions(1)
 
+  const ensureDockerRemoved = jest
+    .spyOn(tools, 'ensureDockerRemoved')
+    .mockImplementation(async (): Promise<void> => {})
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
     .mockImplementation(async (): Promise<void> => {})
@@ -151,6 +161,9 @@ test('SnapcraftBuilder.build can set the Snapcraft channel', async () => {
 test('SnapcraftBuilder.build can pass additional arguments', async () => {
   expect.assertions(1)
 
+  const ensureDockerRemoved = jest
+    .spyOn(tools, 'ensureDockerRemoved')
+    .mockImplementation(async (): Promise<void> => {})
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
     .mockImplementation(async (): Promise<void> => {})
@@ -187,6 +200,9 @@ test('SnapcraftBuilder.build can pass additional arguments', async () => {
 test('SnapcraftBuilder.build can pass UA token', async () => {
   expect.assertions(1)
 
+  const ensureDockerRemoved = jest
+    .spyOn(tools, 'ensureDockerRemoved')
+    .mockImplementation(async (): Promise<void> => {})
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
     .mockImplementation(async (): Promise<void> => {})

--- a/src/build.ts
+++ b/src/build.ts
@@ -49,6 +49,7 @@ export class SnapcraftBuilder {
 
   async build(): Promise<void> {
     core.startGroup('Installing Snapcraft plus dependencies')
+    await tools.ensureDockerRemoved()
     await tools.ensureSnapd()
     await tools.ensureLXD()
     await tools.ensureSnapcraft(this.snapcraftChannel)


### PR DESCRIPTION
Docker installed is not essentially the problem for this action, but the firewall rule it sets up is.

The removal is preemptive of any other potential future issue.

Implemented as shared by @tomponline

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

---
#42 
CRAFT-1490