### PR TITLE
ci: use an older runner for 4.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         path: ${{ steps.snapcraft.outputs.snap}}
 
   integration-legacy: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         project:


### PR DESCRIPTION
The systemd on 16.04 does not mesh well with cgroups from host later than 18.04.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>