### PR TITLE
CI (test.yml): remove deprecated Ubuntu 18.04 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         project:
-          - core18
           - core20
           - core22
     steps:
@@ -35,7 +34,7 @@ jobs:
         path: ${{ steps.snapcraft.outputs.snap}}
 
   integration-legacy: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         project:
@@ -56,7 +55,6 @@ jobs:
     strategy:
       matrix:
         runner:
-          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Ubuntu 18.04 runner has been removed (deprecated) from GitHub 2 months ago (https://github.com/actions/runner-images/issues/6002), this PR removes it and updates integration-legacy to `ubuntu-20.04`.

An alternative way to run 18.04 is using a container inside the runner (Let me know if you want me to update to it instead).