### PR TITLE
Add ignoreReturnCode to check command options

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -344,24 +344,29 @@ test('ensureLXDNetwork sets up iptables and warns about Docker', async () => {
     'Installed docker related packages might interfere with LXD networking: moby-runc'
   )
   expect(execMock).toHaveBeenNthCalledWith(1, 'dpkg', ['-l', 'moby-buildx'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(2, 'dpkg', ['-l', 'moby-engine'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(3, 'dpkg', ['-l', 'moby-cli'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(4, 'dpkg', ['-l', 'moby-compose'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(
     5,
     'dpkg',
     ['-l', 'moby-containerd'],
-    {silent: true}
+    {ignoreReturnCode: true, silent: true}
   )
   expect(execMock).toHaveBeenNthCalledWith(6, 'dpkg', ['-l', 'moby-runc'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(7, 'sudo', [
@@ -393,24 +398,29 @@ test('ensureLXDNetwork sets up iptables and warns only about installed packages'
       'moby-buildx,moby-engine,moby-cli,moby-compose,moby-containerd,moby-runc'
   )
   expect(execMock).toHaveBeenNthCalledWith(1, 'dpkg', ['-l', 'moby-buildx'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(2, 'dpkg', ['-l', 'moby-engine'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(3, 'dpkg', ['-l', 'moby-cli'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(4, 'dpkg', ['-l', 'moby-compose'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(
     5,
     'dpkg',
     ['-l', 'moby-containerd'],
-    {silent: true}
+    {ignoreReturnCode: true, silent: true}
   )
   expect(execMock).toHaveBeenNthCalledWith(6, 'dpkg', ['-l', 'moby-runc'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(7, 'sudo', [

--- a/dist/index.js
+++ b/dist/index.js
@@ -4174,7 +4174,7 @@ async function ensureLXDNetwork() {
         'moby-runc'
     ];
     const installedPackages = [];
-    const options = { silent: true };
+    const options = { silent: true, ignoreReturnCode: true };
     for (const mobyPackage of mobyPackages) {
         if ((await exec.exec('dpkg', ['-l', mobyPackage], options)) === 0) {
             installedPackages.push(mobyPackage);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -39,7 +39,7 @@ export async function ensureLXDNetwork(): Promise<void> {
     'moby-runc'
   ]
   const installedPackages: string[] = []
-  const options = {silent: true}
+  const options = {silent: true, ignoreReturnCode: true}
   for (const mobyPackage of mobyPackages) {
     if ((await exec.exec('dpkg', ['-l', mobyPackage], options)) === 0) {
       installedPackages.push(mobyPackage)


### PR DESCRIPTION
When using `@actions/exec`, the `exec` function will throw an error if the command's exit code is non-zero. If a non-zero return code is expected or accepted , the `ignoreReturnCode` option should be set in the execution options.

https://github.com/actions/toolkit/blob/7b617c260dff86f8d044d5ab0425444b29fa0d18/packages/exec/src/interfaces.ts#L27-L28
```
  /** optional.  defaults to failing on non zero.  ignore will not fail leaving it up to the caller */
  ignoreReturnCode?: boolean
```

---
Fixes #60