### PR TITLE
Fail action when the build fails to produce the exact number of snaps requested

### DIFF
--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -239,12 +239,35 @@ test('SnapcraftBuilder.outputSnap fails if there are no snaps', async () => {
     )
 
   await expect(builder.outputSnap()).rejects.toThrow(
-    'No snap files produced by build'
+    'Not enough snaps produced (Expected: 1, Got: 0)'
   )
   expect(readdir).toHaveBeenCalled()
 })
 
 test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
+  expect.assertions(2)
+
+  const projectDir = 'project-root'
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: projectDir,
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: 'remote-build --build-for=arm64,amd64',
+    uaToken: ''
+  })
+
+  const readdir = jest
+    .spyOn(builder, '_readdir')
+    .mockImplementation(
+      async (path: string): Promise<string[]> => ['one.snap', 'two.snap']
+    )
+
+  await expect(builder.outputSnap()).resolves.toEqual('project-root/one.snap')
+  expect(readdir).toHaveBeenCalled()
+})
+
+test('SnapcraftBuilder.outputSnap fails if more snaps are produced than expected',
+  async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
@@ -262,6 +285,33 @@ test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
       async (path: string): Promise<string[]> => ['one.snap', 'two.snap']
     )
 
-  await expect(builder.outputSnap()).resolves.toEqual('project-root/one.snap')
+  await expect(builder.outputSnap()).rejects.toThrow(
+    'Not enough snaps produced (Expected: 1, Got: 2)'
+  )
+  expect(readdir).toHaveBeenCalled()
+})
+
+test('SnapcraftBuilder.outputSnap fails if less snaps are produced than expected',
+  async () => {
+  expect.assertions(2)
+
+  const projectDir = 'project-root'
+  const builder = new build.SnapcraftBuilder({
+    projectRoot: projectDir,
+    includeBuildInfo: true,
+    snapcraftChannel: 'stable',
+    snapcraftArgs: 'remote-build --build-for=arm64,amd64,i386',
+    uaToken: ''
+  })
+
+  const readdir = jest
+    .spyOn(builder, '_readdir')
+    .mockImplementation(
+      async (path: string): Promise<string[]> => ['one.snap', 'two.snap']
+    )
+
+  await expect(builder.outputSnap()).rejects.toThrow(
+    'Not enough snaps produced (Expected: 3, Got: 2)'
+  )
   expect(readdir).toHaveBeenCalled()
 })

--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -266,8 +266,7 @@ test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
   expect(readdir).toHaveBeenCalled()
 })
 
-test('SnapcraftBuilder.outputSnap fails if more snaps are produced than expected',
-  async () => {
+test('SnapcraftBuilder.outputSnap fails if more snaps are produced than expected', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
@@ -291,8 +290,7 @@ test('SnapcraftBuilder.outputSnap fails if more snaps are produced than expected
   expect(readdir).toHaveBeenCalled()
 })
 
-test('SnapcraftBuilder.outputSnap fails if less snaps are produced than expected',
-  async () => {
+test('SnapcraftBuilder.outputSnap fails if less snaps are produced than expected', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'

--- a/dist/index.js
+++ b/dist/index.js
@@ -27301,18 +27301,12 @@ class SnapcraftBuilder {
         return await external_fs_.promises.readdir(dir);
     }
     getOuputSnapCount() {
-        const argsArr = this.snapcraftArgs.split(' ');
+        const argsArr = this.snapcraftArgs.split(/\s+/);
         for (const [index, element] of argsArr.entries()) {
             if (element.includes('--build-for') || element.includes('--build-on')) {
-                let archArg = null;
-                if (element.includes('=')) {
-                    //build-(on|for)=...
-                    archArg = element.split('=')[1];
-                }
-                else {
-                    //build-(on|for) ...
-                    archArg = argsArr[index + 1];
-                }
+                const archArg = element.includes('=')
+                    ? element.split('=')[1]
+                    : argsArr[index + 1];
                 return archArg.split(',').length;
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -27300,14 +27300,33 @@ class SnapcraftBuilder {
     async _readdir(dir) {
         return await external_fs_.promises.readdir(dir);
     }
+    getOuputSnapCount() {
+        const argsArr = this.snapcraftArgs.split(' ');
+        for (const [index, element] of argsArr.entries()) {
+            if (element.includes('--build-for') || element.includes('--build-on')) {
+                let archArg = null;
+                if (element.includes('=')) {
+                    //build-(on|for)=...
+                    archArg = element.split('=')[1];
+                }
+                else {
+                    //build-(on|for) ...
+                    archArg = argsArr[index + 1];
+                }
+                return archArg.split(',').length;
+            }
+        }
+        // build-(on|for) wasn't found, count should be 1
+        // default arch is the builder arch (for non remote as well)
+        return 1;
+    }
     async outputSnap() {
         const files = await this._readdir(this.projectRoot);
         const snaps = files.filter(name => name.endsWith('.snap'));
-        if (snaps.length === 0) {
-            throw new Error('No snap files produced by build');
-        }
-        if (snaps.length > 1) {
-            core.warning(`Multiple snaps found in ${this.projectRoot}`);
+        const expectedCount = this.getOuputSnapCount();
+        if (snaps.length !== expectedCount) {
+            throw new Error('Not enough snaps produced ' +
+                `(Expected: ${expectedCount}, Got: ${snaps.length})`);
         }
         return external_path_.join(this.projectRoot, snaps[0]);
     }

--- a/src/build.ts
+++ b/src/build.ts
@@ -88,35 +88,35 @@ export class SnapcraftBuilder {
   }
 
   getOuputSnapCount(): number {
-    let args_arr = this.snapcraftArgs.split(" ");
-    for (const [index, element] of args_arr.entries()) {
-      if(element.includes("--build-for") || element.includes("--build-on")){
-        let arch_arg = null;
-        if(element.includes("=")){
+    const argsArr = this.snapcraftArgs.split(' ')
+    for (const [index, element] of argsArr.entries()) {
+      if (element.includes('--build-for') || element.includes('--build-on')) {
+        let archArg = null
+        if (element.includes('=')) {
           //build-(on|for)=...
-          arch_arg = element.split("=")[1];
-        }else{
+          archArg = element.split('=')[1]
+        } else {
           //build-(on|for) ...
-          arch_arg = args_arr[index + 1];
+          archArg = argsArr[index + 1]
         }
-        return arch_arg.split(",").length;
+        return archArg.split(',').length
       }
     }
     // build-(on|for) wasn't found, count should be 1
     // default arch is the builder arch (for non remote as well)
-    return 1;
+    return 1
   }
 
   async outputSnap(): Promise<string> {
     const files = await this._readdir(this.projectRoot)
     const snaps = files.filter(name => name.endsWith('.snap'))
 
-    let expected_count = this.getOuputSnapCount()
+    const expectedCount = this.getOuputSnapCount()
 
-    if (snaps.length != expected_count) {
+    if (snaps.length !== expectedCount) {
       throw new Error(
         'Not enough snaps produced ' +
-        `(Expected: ${expected_count}, Got: ${snaps.length})`
+          `(Expected: ${expectedCount}, Got: ${snaps.length})`
       )
     }
     return path.join(this.projectRoot, snaps[0])

--- a/src/build.ts
+++ b/src/build.ts
@@ -90,9 +90,9 @@ export class SnapcraftBuilder {
   getOuputSnapCount(): int {
     args_arr = this.snapcraftArgs.split(" ");
     for (const [index, element] of args_arr.entries()) {
-      if(element.indexOf("--build-for") == 0 || element.indexOf("--build-on") == 0){
+      if(element.includes("--build-for") || element.includes("--build-on")){
         arch_arg = null;
-        if(element.indexOf("=") > 0){
+        if(element.includes("=")){
           //build-(on|for)=...
           arch_arg = element.split("=")[1];
         }else{

--- a/src/build.ts
+++ b/src/build.ts
@@ -87,11 +87,11 @@ export class SnapcraftBuilder {
     return await fs.promises.readdir(dir)
   }
 
-  getOuputSnapCount(): int {
-    args_arr = this.snapcraftArgs.split(" ");
+  getOuputSnapCount(): number {
+    let args_arr = this.snapcraftArgs.split(" ");
     for (const [index, element] of args_arr.entries()) {
       if(element.includes("--build-for") || element.includes("--build-on")){
-        arch_arg = null;
+        let arch_arg = null;
         if(element.includes("=")){
           //build-(on|for)=...
           arch_arg = element.split("=")[1];
@@ -111,12 +111,12 @@ export class SnapcraftBuilder {
     const files = await this._readdir(this.projectRoot)
     const snaps = files.filter(name => name.endsWith('.snap'))
 
-    expected_count = this.getOuputSnapCount()
+    let expected_count = this.getOuputSnapCount()
 
     if (snaps.length != expected_count) {
       throw new Error(
-        'Not enough snap files produced'
-        '(Expected: ${expected_count}, Got: ${snaps.length})'
+        'Not enough snap files produced \
+        (Expected: ${expected_count}, Got: ${snaps.length})'
       )
     }
     return path.join(this.projectRoot, snaps[0])

--- a/src/build.ts
+++ b/src/build.ts
@@ -115,8 +115,8 @@ export class SnapcraftBuilder {
 
     if (snaps.length != expected_count) {
       throw new Error(
-        'Not enough snap files produced \
-        (Expected: ${expected_count}, Got: ${snaps.length})'
+        'Not enough snaps produced ' +
+        `(Expected: ${expected_count}, Got: ${snaps.length})`
       )
     }
     return path.join(this.projectRoot, snaps[0])

--- a/src/build.ts
+++ b/src/build.ts
@@ -88,17 +88,12 @@ export class SnapcraftBuilder {
   }
 
   getOuputSnapCount(): number {
-    const argsArr = this.snapcraftArgs.split(' ')
+    const argsArr = this.snapcraftArgs.split(/\s+/)
     for (const [index, element] of argsArr.entries()) {
       if (element.includes('--build-for') || element.includes('--build-on')) {
-        let archArg = null
-        if (element.includes('=')) {
-          //build-(on|for)=...
-          archArg = element.split('=')[1]
-        } else {
-          //build-(on|for) ...
-          archArg = argsArr[index + 1]
-        }
+        const archArg = element.includes('=')
+          ? element.split('=')[1]
+          : argsArr[index + 1]
         return archArg.split(',').length
       }
     }


### PR DESCRIPTION
## Description

In checkbox we use this action to trigger [remote builds](https://github.com/canonical/checkbox/blob/main/.github/workflows/checkbox-core-snap-daily-builds.yml#L66) via snapcraft. Right now we don't get any failure out of it even when it actually should fail because as long as at least one snap is produced the action will pass ([Snapcraft never returns 1 due toremote-build failing](https://github.com/snapcore/snapcraft/pull/4400)). This is a problem in general, but specifically right now we are dealing with some flaky builds and we are unable to retry them because we have no way of knowing if snapcraft failed or not. 

This introduces a new check after a build is done, comparing the amount of requested artifacts (namely: 1 for any build that does not include a `--build-(on|for)`) against the number that is actually produced. If the two differ, an error is raised

## Testing

This introduces two new tests (and fixes the text for 0 snaps), to test that a mismatch between requested and produced always fails. I have tested this contribution via `npm test` and `npm run all`