### PR TITLE
feat: expose `max-parallel-build-count` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,12 @@ An example workflow with UA token stored as secret `UA_TOKEN`:
       with:
         ua-token: ${{ secrets.UA_TOKEN }}
 ```
+
+### `max-parallel-build-count`
+
+Sets the value of the environment variable `SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT` 
+to control the maximum number of parallel builds during the snap build & pack
+process.
+
+This may be useful for snaps with particularly large compilation jobs that
+can cause Github Actions runners to run out of resources and hang.

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,13 @@ inputs:
 
       Snapcraft will detach the token when no longer required.
     default: ''
+  max-parallel-build-count:
+    description: >
+      Sets the value of the environment variable
+      `SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT` to control
+      the maximum number of parallel builds during the
+      snap build & pack process.
+    default: ''
 outputs:
   snap:
     description: 'The file name of the resulting snap.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapcraft-build-action",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "A Github action that build snapcraft projects",
   "main": "lib/main.js",

--- a/src/build.ts
+++ b/src/build.ts
@@ -30,6 +30,7 @@ interface SnapcraftBuilderOptions {
   snapcraftChannel: string
   snapcraftArgs: string
   uaToken: string
+  maxParallelBuildCount: string
 }
 
 export class SnapcraftBuilder {
@@ -38,6 +39,7 @@ export class SnapcraftBuilder {
   snapcraftChannel: string
   snapcraftArgs: string
   uaToken: string
+  maxParallelBuildCount: string
 
   constructor(options: SnapcraftBuilderOptions) {
     this.projectRoot = expandHome(options.projectRoot)
@@ -45,6 +47,7 @@ export class SnapcraftBuilder {
     this.snapcraftChannel = options.snapcraftChannel
     this.snapcraftArgs = options.snapcraftArgs
     this.uaToken = options.uaToken
+    this.maxParallelBuildCount = options.maxParallelBuildCount
   }
 
   async build(): Promise<void> {
@@ -65,6 +68,10 @@ export class SnapcraftBuilder {
     env['SNAPCRAFT_IMAGE_INFO'] = JSON.stringify(imageInfo)
     if (this.includeBuildInfo) {
       env['SNAPCRAFT_BUILD_INFO'] = '1'
+    }
+
+    if (this.maxParallelBuildCount) {
+      env['SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT'] = `${this.maxParallelBuildCount}`
     }
 
     let snapcraft = 'snapcraft'

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,13 +12,15 @@ async function run(): Promise<void> {
     const snapcraftChannel = core.getInput('snapcraft-channel')
     const snapcraftArgs = core.getInput('snapcraft-args')
     const uaToken = core.getInput('ua-token')
+    const maxParallelBuildCount = core.getInput('max-parallel-build-count')
 
     const builder = new SnapcraftBuilder({
       projectRoot,
       includeBuildInfo,
       snapcraftChannel,
       snapcraftArgs,
-      uaToken
+      uaToken,
+      maxParallelBuildCount
     })
     await builder.build()
     const snap = await builder.outputSnap()


### PR DESCRIPTION
Introduces a new input that sets the value of the environment variable `SNAPCRAFT_MAX_PARALLEL_BUILD_COUNT` 
to control the maximum number of parallel builds during the snap build & pack
process.

This may be useful for snaps with particularly large compilation jobs that
can cause Github Actions runners to run out of resources and hang.

I also bumped the package version in the case that this merges, so the change is available in `1.3.0`.