### PR TITLE
Test the latest beta ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
         runner:
           - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
I suspect that [Ubuntu 24.04 has issues](https://github.com/actions/runner-images/issues/9932) based on a project I've been trying to get on 24.04. The operation times out at /use/bin/sg while waiting for a password.

```

Installing Snapcraft plus dependencies
  Ensuring runner is in the lxd group...
  /usr/bin/sudo groupadd --force --system lxd
  /usr/bin/sudo usermod --append --groups lxd runner
  Installing LXD...
  /usr/bin/sudo snap install lxd
  2024-05-24T02:38:28Z INFO Waiting for automatic snapd restart...
  lxd (5.21/stable) 5.21.1-d46c406 from Canonical** installed
  Initialising LXD...
  /usr/bin/sudo lxd init --auto
  Installed docker related packages might interfere with LXD networking: 
  /usr/bin/sudo iptables -P FORWARD ACCEPT
  Installing Snapcraft...
  /usr/bin/sudo snap install --channel stable --classic snapcraft
  snapcraft 8.2.8 from Canonical** installed
/usr/bin/sg lxd -c snapcraft
Password: 
Error: The operation was canceled. // Timeout
```