### PR TITLE
Support the Ubuntu 24.04 Github runner image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         project:
           - core20
           - core22
+          - core24
     steps:
     - uses: actions/checkout@v4
     - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,12 @@ jobs:
       id: snapcraft
       with:
         path: './test-projects/${{ matrix.project }}'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: 'snap'
+        name: 'snap-${{ matrix.project }}'
         path: ${{ steps.snapcraft.outputs.snap}}
+        compression-level: 0
+        retention-days: 7
 
   integration-legacy: # make sure the action works on a clean machine without building
     runs-on: ubuntu-20.04
@@ -49,10 +51,25 @@ jobs:
       with:
         path: './test-projects/${{ matrix.project }}'
         snapcraft-channel: 4.x/stable
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: 'snap'
+        name: 'snap-${{ matrix.project }}'
         path: ${{ steps.snapcraft.outputs.snap}}
+        compression-level: 0
+        retention-days: 7
+
+  collect-artifacts:
+    needs:
+      - integration
+      - integration-legacy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/upload-artifact/merge@v4
+      with:
+        name: snap
+        pattern: snap-*
+        delete-merged: true
+        retention-days: 7
 
   check-runner: # make sure the action works on each VM image
     strategy:

--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -64,18 +64,23 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
   })
   await builder.build()
 
+  const user = os.userInfo().username
   expect(ensureSnapd).toHaveBeenCalled()
   expect(ensureLXD).toHaveBeenCalled()
   expect(ensureSnapcraft).toHaveBeenCalled()
-  expect(execMock).toHaveBeenCalledWith('sg', ['lxd', '-c', 'snapcraft'], {
-    cwd: projectDir,
-    env: expect.objectContaining({
-      SNAPCRAFT_BUILD_ENVIRONMENT: 'lxd',
-      SNAPCRAFT_BUILD_INFO: '1',
-      SNAPCRAFT_IMAGE_INFO:
-        '{"build_url":"https://github.com/user/repo/actions/runs/42"}'
-    })
-  })
+  expect(execMock).toHaveBeenCalledWith(
+    'sudo',
+    ['-u', user, '-E', 'snapcraft'],
+    {
+      cwd: projectDir,
+      env: expect.objectContaining({
+        SNAPCRAFT_BUILD_ENVIRONMENT: 'lxd',
+        SNAPCRAFT_BUILD_INFO: '1',
+        SNAPCRAFT_IMAGE_INFO:
+          '{"build_url":"https://github.com/user/repo/actions/runs/42"}'
+      })
+    }
+  )
 })
 
 test('SnapcraftBuilder.build can disable build info', async () => {
@@ -107,7 +112,7 @@ test('SnapcraftBuilder.build can disable build info', async () => {
   })
   await builder.build()
 
-  expect(execMock).toHaveBeenCalledWith('sg', expect.any(Array), {
+  expect(execMock).toHaveBeenCalledWith('sudo', expect.any(Array), {
     cwd: expect.any(String),
     env: expect.not.objectContaining({
       // No SNAPCRAFT_BUILD_INFO variable
@@ -177,9 +182,10 @@ test('SnapcraftBuilder.build can pass additional arguments', async () => {
   })
   await builder.build()
 
+  const user = os.userInfo().username
   expect(execMock).toHaveBeenCalledWith(
-    'sg',
-    ['lxd', '-c', 'snapcraft --foo --bar'],
+    'sudo',
+    ['-u', user, '-E', 'snapcraft', '--foo', '--bar'],
     expect.anything()
   )
 })
@@ -213,9 +219,10 @@ test('SnapcraftBuilder.build can pass UA token', async () => {
   })
   await builder.build()
 
+  const user = os.userInfo().username
   expect(execMock).toHaveBeenCalledWith(
-    'sg',
-    ['lxd', '-c', 'snapcraft --ua-token test-ua-token'],
+    'sudo',
+    ['-u', user, '-E', 'snapcraft', '--ua-token', 'test-ua-token'],
     expect.anything()
   )
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -27283,14 +27283,15 @@ class SnapcraftBuilder {
         if (this.includeBuildInfo) {
             env['SNAPCRAFT_BUILD_INFO'] = '1';
         }
-        let snapcraft = 'snapcraft';
+        const snapcraft = ['snapcraft'];
         if (this.snapcraftArgs) {
-            snapcraft = `${snapcraft} ${this.snapcraftArgs}`;
+            snapcraft.push(...this.snapcraftArgs.split(/\s+/));
         }
         if (this.uaToken) {
-            snapcraft = `${snapcraft} --ua-token ${this.uaToken}`;
+            snapcraft.push('--ua-token', this.uaToken);
         }
-        await exec.exec('sg', ['lxd', '-c', snapcraft], {
+        const user = external_os_.userInfo().username;
+        await exec.exec('sudo', ['-u', user, '-E'].concat(snapcraft), {
             cwd: this.projectRoot,
             env
         });

--- a/src/build.ts
+++ b/src/build.ts
@@ -67,15 +67,16 @@ export class SnapcraftBuilder {
       env['SNAPCRAFT_BUILD_INFO'] = '1'
     }
 
-    let snapcraft = 'snapcraft'
+    const snapcraft = ['snapcraft']
     if (this.snapcraftArgs) {
-      snapcraft = `${snapcraft} ${this.snapcraftArgs}`
+      snapcraft.push(...this.snapcraftArgs.split(/\s+/))
     }
     if (this.uaToken) {
-      snapcraft = `${snapcraft} --ua-token ${this.uaToken}`
+      snapcraft.push('--ua-token', this.uaToken)
     }
 
-    await exec.exec('sg', ['lxd', '-c', snapcraft], {
+    const user = os.userInfo().username
+    await exec.exec('sudo', ['-u', user, '-E'].concat(snapcraft), {
       cwd: this.projectRoot,
       env
     })

--- a/test-projects/core24/hello.c
+++ b/test-projects/core24/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Hello world\n");
+    return 0;
+}

--- a/test-projects/core24/meson.build
+++ b/test-projects/core24/meson.build
@@ -1,0 +1,3 @@
+project('test-build-action', 'c', version : '0.1')
+
+executable('hello', 'hello.c', install : true)

--- a/test-projects/core24/snap/snapcraft.yaml
+++ b/test-projects/core24/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: test-build-action-core24
+base: core24
+version: '0.1'
+summary: A simple test snap used to test the Github build action
+description: ...
+
+grade: devel
+confinement: strict
+
+apps:
+  test-build-action:
+    command: bin/hello
+
+parts:
+  build:
+    plugin: meson
+    build-packages:
+      - meson
+    meson-parameters:
+      - --prefix=/
+    source: .


### PR DESCRIPTION
Changes to the `ubuntu-24.04` image mean that our way of starting Snapcraft hangs, waiting for a password from `sg` (as detailed in https://github.com/actions/runner-images/issues/9932). This PR instead uses `sudo -u $USER` to run Snapcraft with a refreshed set of group memberships. This appears to work on the `ubuntu-24.04` image as well as the older images.

I've also updated the CI testing matrixes to test on the new image and test a `base: core24` project.