### PR TITLE
feat: update node version

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -27,10 +27,7 @@ test('ensureSnapd installs snapd if needed', async () => {
   const statMock = jest
     .spyOn(fs.promises, 'stat')
     .mockImplementation(async (filename: fs.PathLike): Promise<fs.Stats> => {
-      const s = new fs.Stats()
-      s.uid = 0
-      s.gid = 0
-      return s
+      return {uid: 0, gid: 0} as unknown as fs.Stats
     })
   const execMock = jest
     .spyOn(exec, 'exec')
@@ -71,10 +68,7 @@ test('ensureSnapd is a no-op if snapd is installed', async () => {
   const statMock = jest
     .spyOn(fs.promises, 'stat')
     .mockImplementation(async (filename: fs.PathLike): Promise<fs.Stats> => {
-      const s = new fs.Stats()
-      s.uid = 0
-      s.gid = 0
-      return s
+      return {uid: 0, gid: 0} as unknown as fs.Stats
     })
   const execMock = jest
     .spyOn(exec, 'exec')
@@ -105,10 +99,7 @@ test('ensureSnapd fixes permissions on the root directory', async () => {
   const statMock = jest
     .spyOn(fs.promises, 'stat')
     .mockImplementation(async (filename: fs.PathLike): Promise<fs.Stats> => {
-      const s = new fs.Stats()
-      s.uid = 500
-      s.gid = 0
-      return s
+      return {uid: 500, gid: 0} as unknown as fs.Stats
     })
   const execMock = jest
     .spyOn(exec, 'exec')

--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ outputs:
   snap:
     description: 'The file name of the resulting snap.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.14.10",
+        "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "^7.16.0",
         "@typescript-eslint/parser": "^7.16.0",
         "@vercel/ncc": "^0.38.1",
@@ -1401,12 +1401,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6743,10 +6744,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.14.10",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "@vercel/ncc": "^0.38.1",


### PR DESCRIPTION
this action emits the following warning on `ubuntu-latest`:

```
build-snap (amd64, ubuntu-24.04)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: canonical/action-build@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

this PR updates the node version this action is using. it also updated the dev node version and therefore makes a tiny patch to tests since in node 24 `fs.Stats` is now private:

```diff
.mockImplementation(async (filename: fs.PathLike): Promise<fs.Stats> => {
-  const s = new fs.Stats()
-  s.uid = 0
-  s.gid = 0
-  return s
+  return {uid: 0, gid: 0} as unknown as fs.Stats
})
```

(the double cast is needed to appease typescript)

- closes https://github.com/canonical/action-build/issues/94
